### PR TITLE
Remove unnecessary password attribute in osgi.bundle

### DIFF
--- a/nucleus/core/kernel/osgi.bundle
+++ b/nucleus/core/kernel/osgi.bundle
@@ -27,8 +27,8 @@
 
 # dependent flashlight package resolved at runtime
 DynamicImport-Package: org.glassfish.flashlight.provider, \
-                       org.objectweb.asm;password=GlassFish, \
-                       org.objectweb.asm.commons;password=GlassFish
+                       org.objectweb.asm, \
+                       org.objectweb.asm.commons
 
 # Only in non-OSGi embedded mode, kernel depends on logging package, so
 # optionally depend on that pkg. This way, when GF is embedded in

--- a/nucleus/deployment/common/osgi.bundle
+++ b/nucleus/deployment/common/osgi.bundle
@@ -30,5 +30,5 @@ Import-Package: \
                         
 DynamicImport-Package: \
                         org.glassfish.flashlight.provider, \
-                        org.objectweb.asm;password=GlassFish, \
-                        org.objectweb.asm.commons;password=GlassFish
+                        org.objectweb.asm, \
+                        org.objectweb.asm.commons

--- a/nucleus/flashlight/framework/osgi.bundle
+++ b/nucleus/flashlight/framework/osgi.bundle
@@ -21,8 +21,8 @@
                             org.glassfish.flashlight.provider; version=${project.osgi.version}
 
 DynamicImport-Package: \
-                        org.objectweb.asm;password=GlassFish, \
-                        org.objectweb.asm.commons;password=GlassFish \
+                        org.objectweb.asm, \
+                        org.objectweb.asm.commons \
 
 
 Bundle-Activator: org.glassfish.flashlight.impl.core.FlashlightBundleActivator


### PR DESCRIPTION
Removes the password attribute `;password=GlassFish` in osgi.bundle, which is unnecessary since the repackaged asm is no longer used.
This fixes `java.lang.NoClassDefFoundError: org/objectweb/asm/ClassVisitor` in jdbc devtests.

Signed-off-by: Takahiro Nagao <nagao.takahiro@fujitsu.com>